### PR TITLE
Revert back to jQuery 3.4.1 to fix broken bootstrap menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,9 +60,9 @@
       "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "moment": {
       "version": "2.24.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "chart.js": "^2.8.0",
     "daterangepicker": "^3.0.5",
     "font-awesome": "^4.7.0",
-    "jquery": "^3.5.0"
+    "jquery": "~3.4.1"
   },
   "devDependencies": {
     "prettier": "*"


### PR DESCRIPTION
Five days ago @dependabot [proposed](https://github.com/contuga/contuga-web/pull/4) updating jQuery from 3.4.1 to 3.5.0. At first glance, everything worked and having trust in semantic versioning I accepted the pull request. Unfortunately, this caused an issue in Bootstrap and the collapsable mobile menu got broken. The project uses Bootstrap 4.3.1 but the problem exists even in the latest version 4.4.1. It is fixed [17 days ago](https://github.com/twbs/bootstrap/pull/30559) in [v4-dev](https://github.com/twbs/bootstrap/tree/v4-dev) but it's not released yet. We have to stick to jQuery 3.4.1 until the newer Bootstrap version is out.

I will merge this immediately in order to update the production environment. I believe there won't be any objection.

Here is a link to the issue: https://github.com/twbs/bootstrap/issues/30553