### PR TITLE
Feature: Add create form in transaction list page

### DIFF
--- a/contuga/contrib/transactions/forms.py
+++ b/contuga/contrib/transactions/forms.py
@@ -2,7 +2,20 @@ from django import forms
 from django.utils.translation import pgettext_lazy, ugettext_lazy as _
 from django.core.exceptions import ValidationError, NON_FIELD_ERRORS
 
+from . import models
 from contuga.contrib.accounts.models import Account
+from contuga.contrib.categories.models import Category
+
+
+class TransactionCreateForm(forms.ModelForm):
+    class Meta:
+        model = models.Transaction
+        fields = ("type", "amount", "account", "category", "description")
+
+    def __init__(self, user, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["account"].queryset = Account.objects.active(owner=user)
+        self.fields["category"].queryset = Category.objects.filter(author=user)
 
 
 class TransactionFilterForm(forms.Form):

--- a/contuga/contrib/transactions/templates/transactions/includes/transaction_create_form.html
+++ b/contuga/contrib/transactions/templates/transactions/includes/transaction_create_form.html
@@ -1,0 +1,28 @@
+
+{% load i18n %}
+
+<div class="collapse" id="createFormContainer" data-parent="#actionGroup">
+  <form method="POST" action="{% url 'transactions:create' %}">
+    {% csrf_token %}
+    <div class="row">
+      <div class="col-12 col-md-6">
+        {% include 'contuga/forms/field.html' with field=form.type %}
+      </div>
+      <div class="col-12 col-md-6">
+        {% include 'contuga/forms/field.html' with field=form.amount %}
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12 col-md-6">
+        {% include 'contuga/forms/field.html' with field=form.account %}
+      </div>
+      <div class="col-12 col-md-6">
+        {% include 'contuga/forms/field.html' with field=form.category %}
+      </div>
+    </div>
+    {% include 'contuga/forms/field.html' with field=form.description %}
+    <button type="submit" class="btn btn-primary">
+      {% trans "Save" context "verb" %}
+    </button>
+  </form>
+</div>

--- a/contuga/contrib/transactions/templates/transactions/transaction_list.html
+++ b/contuga/contrib/transactions/templates/transactions/transaction_list.html
@@ -8,10 +8,10 @@
   <div class="row" id="actionGroup">
     <div class="col-12">
       <div class="d-flex justify-content-end">
-        <a class="btn btn-primary btn-action" href="{% url 'transactions:create' %}" role="button">
+        <button class="btn btn-primary btn-action" type="button" data-toggle="collapse" data-target="#createFormContainer">
           <i class="fa fa-plus"></i>
           <span class="d-none d-sm-inline">{% trans "Add new" %}</span>
-        </a>
+        </button>
         <button class="btn btn-dark btn-action" type="button" data-toggle="collapse" data-target="#exportFormContainer">
           <i class="fa fa-download"></i>
           <span class="d-none d-sm-inline">{% trans "Export" %}</span>
@@ -21,6 +21,7 @@
           <span class="d-none d-sm-inline">{% trans "Filters" %}</span>
         </button>
       </div>
+      {% include "transactions/includes/transaction_create_form.html" with form=create_form %}
       {% include "transactions/includes/transaction_export_form.html" %}
       {% include "transactions/includes/transaction_filter_form.html" %}
     </div>

--- a/contuga/contrib/transactions/tests/test_views.py
+++ b/contuga/contrib/transactions/tests/test_views.py
@@ -2,8 +2,10 @@ from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 
+from contuga.mixins import TestMixin
 from contuga.contrib.transactions.models import Transaction
-from contuga.contrib.transactions.constants import EXPENDITURE
+from contuga.contrib.transactions.constants import INCOME, EXPENDITURE
+from contuga.contrib.settings.models import Settings
 from contuga.contrib.categories.models import Category
 from contuga.contrib.accounts.models import Account
 from contuga.contrib.accounts.constants import BGN
@@ -11,7 +13,7 @@ from contuga.contrib.accounts.constants import BGN
 UserModel = get_user_model()
 
 
-class TransactionViewTests(TestCase):
+class TransactionViewTests(TestCase, TestMixin):
     def setUp(self):
         self.user = UserModel.objects.create_user("john.doe@example.com", "password")
         self.category = Category.objects.create(
@@ -36,6 +38,18 @@ class TransactionViewTests(TestCase):
         self.client.force_login(self.user)
 
     def test_list(self):
+        self.create_account(name="Second account name")
+        self.create_account(name="Third account name")
+        self.create_account(name="Fourth account name", is_active=False)
+
+        self.create_category(name="Second category name")
+        self.create_category(name="Third category name")
+
+        other_user = UserModel.objects.create_user(
+            "richard.roe@example.com", "password"
+        )
+        self.create_category(name="Fourth category name", author=other_user)
+
         url = reverse("transactions:list")
         response = self.client.get(url, follow=True)
 
@@ -58,6 +72,57 @@ class TransactionViewTests(TestCase):
         ]
         for field in fields:
             self.assertContains(response=response, text=field)
+
+        # Assert create form is correct
+        form = response.context.get("create_form")
+
+        expected_account_queryset = Account.objects.active()
+        queryset = form.fields["account"].queryset
+        self.assertQuerysetEqual(
+            expected_account_queryset, queryset, transform=lambda x: x
+        )
+
+        expected_category_queryset = Category.objects.filter(author=self.user)
+        queryset = form.fields["category"].queryset
+        self.assertQuerysetEqual(
+            expected_category_queryset, queryset, transform=lambda x: x
+        )
+
+    def test_list_create_form_with_default_settings(self):
+        url = reverse("transactions:list")
+        response = self.client.get(url, follow=True)
+
+        # Assert initial create form data is correct
+        form = response.context.get("create_form")
+
+        category_field = form.fields["category"]
+        self.assertEqual(category_field.initial, None)
+
+        account_field = form.fields["account"]
+        self.assertEqual(account_field.initial, None)
+
+    def test_list_create_form_with_custom_settings(self):
+        settings = Settings.objects.last()
+        settings.default_expenditures_category = self.create_category(
+            transaction_type=EXPENDITURE
+        )
+        settings.default_incomes_category = self.create_category(
+            transaction_type=INCOME
+        )
+        settings.default_account = self.account
+        settings.save()
+
+        url = reverse("transactions:list")
+        response = self.client.get(url, follow=True)
+
+        # Assert initial create form data is correct
+        form = response.context.get("create_form")
+
+        category_field = form.fields["category"]
+        self.assertEqual(category_field.initial, None)
+
+        account_field = form.fields["account"]
+        self.assertEqual(account_field.initial, None)
 
     def test_detail(self):
         url = reverse("transactions:detail", kwargs={"pk": self.transaction.pk})

--- a/contuga/contrib/transactions/views.py
+++ b/contuga/contrib/transactions/views.py
@@ -145,6 +145,11 @@ class TransactionListView(
     def get_queryset(self):
         return super().get_queryset().select_related("category", "account")
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["create_form"] = forms.TransactionCreateForm(user=self.request.user)
+        return context
+
 
 class TransactionDetailView(
     OnlyAuthoredByCurrentUserMixin, mixins.LoginRequiredMixin, generic.DetailView


### PR DESCRIPTION
Having a quick add option in transaction list page will allow us to expand the standard form with additional fields (products, files, etc.) while preserving the old short form for users which prefer to enter fewer details.